### PR TITLE
Fix missing 3D models in KiBot rendering

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container: ghcr.io/inti-cmnb/kicad8_auto_full:latest
 
     permissions:
       contents: write
@@ -34,18 +35,6 @@ jobs:
       - name: Dependencies
         run: |
           sudo apt update
-
-          wget https://github.com/INTI-CMNB/KiBot/releases/download/v1.7.0/kibot_1.7.0-1_all.deb
-          sudo apt install ./kibot*_all.deb
-
-          wget https://github.com/INTI-CMNB/InteractiveHtmlBom/releases/download/v2.9.0-1/interactivehtmlbom.inti-cmnb_2.9.0-1_all.deb
-          sudo apt install ./interactivehtmlbom.inti-cmnb*_all.deb
-
-          wget https://github.com/INTI-CMNB/KiAuto/releases/download/v2.3.2/kiauto_2.3.2-1_all.deb
-          sudo apt install ./kiauto*_all.deb
-
-          sudo add-apt-repository --yes ppa:kicad/kicad-8.0-releases
-          sudo apt install --install-recommends kicad
 
           git clone https://github.com/Kampi/KiCad.git library
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -29,10 +29,6 @@ jobs:
           path: .
           submodules: recursive
 
-      - name: Dependencies
-        run: |
-          git clone https://github.com/Kampi/KiCad.git library
-
       - name: Extract branch name
         shell: bash
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Dependencies
         run: |
-          sudo apt update
-
           git clone https://github.com/Kampi/KiCad.git library
 
       - name: Extract branch name

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,9 +15,6 @@ jobs:
     permissions:
       contents: write
 
-    env:
-      KICAD_LIBRARY: /home/runner/work/ZSWatch-HW/ZSWatch-HW/library
-
     strategy:
       matrix:
         device_type: [Watch, Sensor]


### PR DESCRIPTION
- Replace the manual KiBot installation with a container
- Remove KiCad library from Kampi to switch to the local project library